### PR TITLE
cart is now sometimes null, making this code not throw

### DIFF
--- a/app/components/Cart.jsx
+++ b/app/components/Cart.jsx
@@ -9,8 +9,13 @@ export function CartMain({layout, cart}) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
-  const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
+    Boolean(
+      cart.discountCodes?.filter((code) => code.applicable)
+        .length,
+    )
+  const className = `cart-main ${
+    withDiscount ? 'with-discount' : ''
+  }`
 
   return (
     <div className={className}>


### PR DESCRIPTION
quick fix for this error that started cropping up today:
![image](https://github.com/concrete-utopia/hydrogen-november/assets/2226774/6eead32e-c005-43a5-8eca-c743dee1f788)


I have no idea why cart was not null before and why is it now, but in any case, this question mark fixes it